### PR TITLE
Add command preview definitions

### DIFF
--- a/src/slashcommands/ISlashCommand.ts
+++ b/src/slashcommands/ISlashCommand.ts
@@ -1,4 +1,5 @@
 import { IHttp, IModify, IPersistence, IRead } from '../accessors';
+import { ISlashCommandPreview, ISlashCommandPreviewItem } from './ISlashCommandPreview';
 import { SlashCommandContext } from './SlashCommandContext';
 
 /**
@@ -13,6 +14,13 @@ export interface ISlashCommand {
     i18nDescription: string;
     /** Optional. Permission value required for the user to have to see/use it. */
     permission?: string;
+    /** Lets the clients know that this command does provide preview results. */
+    providesPreview: boolean;
     /** The function which gets called when a user enters the command. */
     executor(context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp, persis: IPersistence): Promise<void>;
+    /** The function which gets called whenever a user starts typing the command and the `providesPreview` is set to true. */
+    previewer?(context: SlashCommandContext, read: IRead, modify: IModify, http: IHttp, persis: IPersistence): Promise<ISlashCommandPreview>;
+    /** The function which gets executed whenever a user selects a preview item. */
+    executePreviewItem?(item: ISlashCommandPreviewItem, context: SlashCommandContext,
+                        read: IRead, modify: IModify, http: IHttp, persis: IPersistence): Promise<void>;
 }

--- a/src/slashcommands/ISlashCommand.ts
+++ b/src/slashcommands/ISlashCommand.ts
@@ -8,7 +8,7 @@ export interface ISlashCommand {
     /** The value which determines what the user types. */
     command: string;
     /** Example of the parameters or an i18n string. */
-    paramsExample: string;
+    i18nParamsExample: string;
     /** i18n string for the description of the command. */
     i18nDescription: string;
     /** Optional. Permission value required for the user to have to see/use it. */

--- a/src/slashcommands/ISlashCommandPreview.ts
+++ b/src/slashcommands/ISlashCommandPreview.ts
@@ -1,0 +1,9 @@
+export interface ISlashCommandPreview {
+    i18nTitle: string;
+    items: Array<ISlashCommandPreviewItem>;
+}
+
+export interface ISlashCommandPreviewItem {
+    id: string;
+    url: string;
+}

--- a/src/slashcommands/index.ts
+++ b/src/slashcommands/index.ts
@@ -1,4 +1,10 @@
 import { ISlashCommand } from './ISlashCommand';
+import { ISlashCommandPreview, ISlashCommandPreviewItem } from './ISlashCommandPreview';
 import { SlashCommandContext } from './SlashCommandContext';
 
-export { ISlashCommand, SlashCommandContext };
+export {
+    ISlashCommand,
+    ISlashCommandPreview,
+    ISlashCommandPreviewItem,
+    SlashCommandContext,
+};


### PR DESCRIPTION
Closes #40 and #41 

This is a proposal for the Apps that want a command to implement a previewer and provide preview items. With this proposal, whenever a preview item is clicked/tapped then another function on the command will be executed that way the decision on how to handle things are left up to the App and not the various clients.